### PR TITLE
Resume Upload Indicator

### DIFF
--- a/src/components/Register/RegisterRender.tsx
+++ b/src/components/Register/RegisterRender.tsx
@@ -104,8 +104,10 @@ interface Props {
 	onSubmit: (result: any) => void;
 	majorState: ReactState<string>;
 	customMajorState: ReactState<string>;
-    // prop rather than state bc it doesn't need to change after initial load; only the next time they register
-	originalUser?: User | null; // used to show existing resume info. 
+	// used to show existing resume info
+	// prop rather than state bc they don't need to change after initial load; only the next time they register
+	originalUser?: User;
+	resumeUploadedAt?: string;
 }
 
 export function RegisterRender({
@@ -114,6 +116,7 @@ export function RegisterRender({
 	majorState,
 	customMajorState,
 	originalUser,
+	resumeUploadedAt,
 }: Props) {
 	const [selectedMajor, setSelectedMajor] = majorState;
 	const [customMajorText, setCustomMajorText] = customMajorState;
@@ -230,13 +233,13 @@ export function RegisterRender({
 							<FormLabel>{title}</FormLabel>
 							<FormControl>{control}</FormControl>
 							{field === "resume" && originalUser?.resume_filename ? (
-								<div className="mt-1 text-sm text-muted-foreground">
+								<div className="mt-1 text-sm text-white">
 									{originalUser.resume_filename}
-									{originalUser.resume_uploaded_at && !isNaN(new Date(originalUser.resume_uploaded_at).getTime()) ? (
-									<> — last uploaded {new Date(originalUser.resume_uploaded_at).toLocaleString()}</>
+									{resumeUploadedAt && !isNaN(new Date(resumeUploadedAt).getTime()) ? (
+									<> — last uploaded {new Date(resumeUploadedAt).toLocaleString()}</>
 									) : null}
 								</div> // only show if they have an existing resume
-									) : null}
+							) : null}
 							{description && (
 								<FormDescription>{description}</FormDescription>
 							)}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,7 +91,6 @@ export interface User {
 	notes: string;
 	resume_format: string;
 	resume_filename?: string | null;
-	resume_uploaded_at?: string | null; // ISO 8601 time if uploaded, null if not
 }
 
 export interface Event {


### PR DESCRIPTION
Added an indicator of previous resume uploads when registering (or updating info through the register command). 
Fixes #95 

**Major Changes**

- Changed profileOrDefaults return to match backend changes
- User is now included as a prop in registerRender in order to access their resume info.
- User interface now includes a filename and upload time.

Tested locally with a pdf and docx upload. Shouldn't need any revisiting as long as it gets passed the same things after we implement the resumes table.