### PR TITLE
Bug Fix- MembersTable HasResume column

### DIFF
--- a/src/components/Tables/MembersTable.tsx
+++ b/src/components/Tables/MembersTable.tsx
@@ -102,7 +102,6 @@ const definition: Definition<MemberListItem>[] = [
 		accessorKey: "resume_upload_date", // only data guaranteed even for old uploads
 		header: "Has Resume",
 		cell: (row) => {
-			// rendering "Yes" or "No"
 			const upload_date = row.getValue<string>("resume_upload_date");
 			const hasResume = upload_date && upload_date !== "";
 			return <>{hasResume ? "Yes" : "No"}</>;
@@ -111,7 +110,6 @@ const definition: Definition<MemberListItem>[] = [
 		type: z.string(),
 		other: {
 			sortingFn: (rowA, rowB) => {
-				// see if they're empty
 				const hasResumeA = Boolean(
 					rowA.getValue<string>("resume_upload_date")
 				);
@@ -130,7 +128,6 @@ function MembersTable() {
 
 	const onGet = async (): Promise<MemberListItem[]> => {
 		const [users, resumes] = await Promise.all([
-			// fetch users and resumes.
 			fetchPath("/users", { method: "GET" }) as Promise<User[]>,
 			fetchPath("/resumes", { method: "GET" }) as Promise<Resume[]>,
 		]);
@@ -138,11 +135,10 @@ function MembersTable() {
 			resumes.map((resume) => [resume.user_id, resume])
 		);
 
-		// join users & resumes
 		return users.map((user) => {
 			const resume = resumesByUserID[user.user_id];
 			return {
-				...user, // spread syntax joining user vars
+				...user,
 				resume_filename: resume?.filename,
 				resume_format: resume?.format,
 				resume_upload_date: resume?.upload_date,
@@ -167,10 +163,7 @@ function MembersTable() {
 				sponsor_email_opt_out: false,
 				join_date: "",
 				notes: "",
-				resume_filename: "",
-				resume_format: "",
 				resume_upload_date: "",
-				resume_is_valid: false,
 			}}
 			onGet={onGet}
 		/>


### PR DESCRIPTION
Fixed a bug where the frontend displays no resume for all members in the membersTable. 
I'd left some resume fields in default values that I never went on to give their own columns. That caused an error, making all MemberListItems default to having empty strings for all those resume fields at the bottom.