### PR TITLE
Piechart Overflow Fix

### DIFF
--- a/src/components/Charts/LabelledPieChart.tsx
+++ b/src/components/Charts/LabelledPieChart.tsx
@@ -23,10 +23,6 @@ interface LegendItem {
 	fill: string;
 }
 
-interface CollapsibleLegendProps {
-	items: LegendItem[];
-}
-
 function CollapsibleLegend({
 	items,
 	config,
@@ -80,8 +76,6 @@ function CollapsibleLegend({
 
 function LabelledPieChart({ title, data }: Props) {
 	const { config, coloredData, total } = useCategoricalChart(data);
-	//console.log("coloredData", coloredData);
-	//console.log("config", config);
 
 	function centerLabel() {
 		return (

--- a/src/components/Charts/LabelledPieChart.tsx
+++ b/src/components/Charts/LabelledPieChart.tsx
@@ -1,23 +1,87 @@
 "use client";
 
-import { Label, Pie, PieChart } from "recharts";
 import {
+	ChartConfig,
 	ChartContainer,
-	ChartLegend,
-	ChartLegendContent,
 	ChartTooltip,
 	ChartTooltipContent,
 } from "@/components/ui/chart";
-import type { CategoricalData } from "../../lib/types";
 import { useCategoricalChart } from "@/hooks/useCategoricalChart";
+import { useState } from "react";
+import { Label, Pie, PieChart } from "recharts";
+import type { CategoricalData } from "../../lib/types";
 
 interface Props {
 	title: string;
 	data: CategoricalData[];
 }
 
+const LEGEND_LIMIT = 5;
+
+interface LegendItem {
+	label: string;
+	fill: string;
+}
+
+interface CollapsibleLegendProps {
+	items: LegendItem[];
+}
+
+function CollapsibleLegend({
+	items,
+	config,
+}: {
+	items: LegendItem[];
+	config: ChartConfig;
+}) {
+	const [showAll, setShowAll] = useState(false);
+
+	const visible = showAll ? items : items.slice(0, LEGEND_LIMIT);
+	const overflow = items.length - LEGEND_LIMIT;
+
+	return (
+		<div className="flex flex-wrap gap-x-4 gap-y-1.5 justify-center text-sm mt-3 px-2">
+			{visible.map((item) => {
+				const color = config[item.label.replace(/ /g, "_")]?.color;
+				return (
+					<div
+						key={item.label}
+						className="flex items-center gap-1.5"
+					>
+						<div
+							className="w-2.5 h-2.5 rounded-sm shrink-0"
+							style={{ background: color }}
+						/>
+						<span className="text-muted-foreground">
+							{item.label}
+						</span>
+					</div>
+				);
+			})}
+			{!showAll && overflow > 0 && (
+				<button
+					onClick={() => setShowAll(true)}
+					className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline transition-colors"
+				>
+					+ {overflow} more
+				</button>
+			)}
+			{showAll && overflow > 0 && (
+				<button
+					onClick={() => setShowAll(false)}
+					className="text-muted-foreground hover:text-foreground underline-offset-2 hover:underline transition-colors"
+				>
+					show less
+				</button>
+			)}
+		</div>
+	);
+}
+
 function LabelledPieChart({ title, data }: Props) {
 	const { config, coloredData, total } = useCategoricalChart(data);
+	//console.log("coloredData", coloredData);
+	//console.log("config", config);
 
 	function centerLabel() {
 		return (
@@ -54,27 +118,32 @@ function LabelledPieChart({ title, data }: Props) {
 	}
 
 	return (
-		<ChartContainer
-			config={config}
-			className="mx-auto aspect-square max-h-[300px]"
-		>
-			<PieChart accessibilityLayer>
-				<ChartTooltip
-					cursor={false}
-					content={<ChartTooltipContent hideLabel />}
-				/>
-				<ChartLegend content={<ChartLegendContent nameKey="label" />} />
-				<Pie
-					data={coloredData}
-					dataKey="count"
-					nameKey="label"
-					innerRadius={60}
-					strokeWidth={5}
-				>
-					{centerLabel()}
-				</Pie>
-			</PieChart>
-		</ChartContainer>
+		<div className="flex flex-col items-center w-full">
+			<ChartContainer
+				config={config}
+				className="mx-auto aspect-square max-h-[300px] w-full"
+			>
+				<PieChart accessibilityLayer>
+					<ChartTooltip
+						cursor={false}
+						content={<ChartTooltipContent hideLabel />}
+					/>
+					<Pie
+						data={coloredData}
+						dataKey="count"
+						nameKey="label"
+						innerRadius={60}
+						strokeWidth={5}
+					>
+						{centerLabel()}
+					</Pie>
+				</PieChart>
+			</ChartContainer>
+			<CollapsibleLegend
+				items={coloredData}
+				config={config}
+			/>
+		</div>
 	);
 }
 


### PR DESCRIPTION
Fixed the piechart legend overflow bug.

The fix involved creating a custom component called the CollapsibleLegend component. This legend only shows the first five majors by return order in the pie chart by default. It also renders a show more button to show the rest of the majors, which wraps around and pushes the top members widget down below it. As such, the return is wrapped in an outer container to stack the chart and custom legend vertically. It is important to note that a future issue that must be dealt with is that there aren't enough colors to cover all of the majors. So far, only five colors are hardcoded but with so many majors, more would be more visually appealing.